### PR TITLE
Bump PyApp to 0.22.0

### DIFF
--- a/.github/workflows/build-devagent.yml
+++ b/.github/workflows/build-devagent.yml
@@ -25,14 +25,10 @@ env:
   PYAPP_PYTHON_VERSION: "3.11"  # underlying Python version
   PYAPP_PROJECT_NAME: "invoke"
   PYAPP_PROJECT_DEPENDENCY_FILE: "/tmp/requirements.txt"
-  PYAPP_EXPOSE_PIP: 1
-  PYAPP_EXPOSE_PYTHON: 1
-  PYAPP_EXPOSE_CACHE: 1
-  PYAPP_EXPOSE_METADATA: 1
-  PYAPP_EXPOSE_PYTHON_PATH: 1
+  PYAPP_EXPOSE_ALL_COMMANDS: 1
   PYTHON_VERSION: "3.11"  # Used in the pipeline itself
   PYAPP_REPO: pyapp  # Path to the PyApp repository
-  PYAPP_VERSION: "0.21.1"
+  PYAPP_VERSION: "0.22.0"
   CARGO_COMMAND: cargo  # Cargo command to run
   VERSION_SUFFIX: "-dev"
   AGENT_REQUIREMENTS: "https://raw.githubusercontent.com/DataDog/datadog-agent/main/requirements.txt"


### PR DESCRIPTION
- Bump to PyApp [0.22.0](https://github.com/ofek/pyapp/releases/tag/v0.22.0)
- Make use of the new option I introduced in PyApp to simplify our config

We do not need to release anything, it won't change anything in the binary that is already released, it will fix the CI though.